### PR TITLE
Made some changes for IE8, what do you think?

### DIFF
--- a/css/plusgallery.css
+++ b/css/plusgallery.css
@@ -251,6 +251,8 @@ background-color: #38beea;
 	width: 100%;
 	height: 100%;
 	z-index: -1;
+	background: transparent;
+	-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#CC000000,endColorstr=#CC000000)"; /* IE8 */
 	background: rgba(0,0,0,.8);
 	text-align: center;
 	z-index: 1000;
@@ -304,6 +306,7 @@ background-color: #38beea;
 }
 
 .pgzoomspacer {
+	display: inline-block;
 	width: 1px;
 	height: 100%;
 	vertical-align: middle;

--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -684,7 +684,7 @@ SLIDEFADE
 					$(window).on('resize',pg.resizeZoom);
 					
 					$.each(pg.imgArray,function(i){
-						pgZoomHTML = pgZoomHTML  + '<li class="pgzoomslide loading" id="pgzoomslide' + i + '" style="width: ' + pg.winWidth + 'px;"><img src="' + pg.imagePath + '/square.gif" class="pgzoomspacer"><span class="pgzoomcaption">' + pg.titleArray[i] + '</span></li>';
+						pgZoomHTML = pgZoomHTML  + '<li class="pgzoomslide loading" id="pgzoomslide' + i + '" style="width: ' + pg.winWidth + 'px;"><div class="pgzoomspacer"></div><span class="pgzoomcaption">' + pg.titleArray[i] + '</span></li>';
 		
 						if(i + 1 == pg.imgArray.length) {
 							//at the end of the loop


### PR DESCRIPTION
I was working on a site a month ago, and was getting a few IE8 issues.  I noticed you may have already resolved these -- went ahead and added them to my fork anyway in case you find the useful.

Adding ms-filter to make background pgzoomview work better.

Changed .pgzoomspacer to display: inline-block

Using .pgzoomspacer as a div instead of image now, I feel it is a slightly cleaner method and also corrects a white line that was appearing intermittently
