### PR TITLE
Bug Fix for Flickr

### DIFF
--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -87,7 +87,7 @@ SLIDEFADE
         _doc.off("click", ".pgalbumlink, #pgthumbhome, .pgthumb, .pgzoomarrow, .pgzoomclose, #pgzoomview, #pgzoomslide, .pgzoomimg");
 
         pg.getDataAttr();
-        console.log( pg.albumId );
+        
         pg.writeHTML();
         if(pg.albumId !== null
           || pg.type == 'instagram'
@@ -350,7 +350,7 @@ SLIDEFADE
           }
         break;
         case 'flickr':
-          console.log( json );
+          
           objPath = json.photosets.photoset;
           albumTotal = objPath.length;
               


### PR DESCRIPTION
Updated flickr calls to use ssl (https instead of http). Flickr API no longer returns requests on http.
