### PR TITLE
Better default for imagePath

### DIFF
--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -49,7 +49,7 @@ SLIDEFADE
     if(lmnt.length === 0) { return false; }
     var pg = {
       /*user defined Defaults*/
-      imagePath: 'images/plusgallery',
+      imagePath: '/images/plusgallery',
       type: null,
       albumTitle: false, //show the album title in single album mode
       albumLimit: 16, //Limit amout of albums to load initially.


### PR DESCRIPTION
Leading with forward slash is a better default in most cases, a reference to
http://myhost.com/somepage/square.gif will give 404.
