### PR TITLE
Updated albumId check

### DIFF
--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -89,7 +89,7 @@ SLIDEFADE
         pg.getDataAttr();
         
         pg.writeHTML();
-        if(pg.albumId !== null
+        if((pg.albumId !== null  && (typeof pg.albumId !== 'undefined'))
           || pg.type == 'instagram'
           || (pg.type == 'local' && !pg.imageData.hasOwnProperty('albums'))){
           //load single Album


### PR DESCRIPTION
Added typeof check on pg.albumId !== 'undefined'

I was attempting to list all the albums on my Picasa account. But, since pg.albumId was coming through as "undefined" it was passing the !==null check and attempting to run pg.loadSingleAlbum instead of pg.loadAlbumData().

Fixed.

Thanks Mang!
