### PR TITLE
Fix broken Flickr URLs and album id bug

### DIFF
--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -89,7 +89,7 @@ SLIDEFADE
         pg.getDataAttr();
         
         pg.writeHTML();
-        if(pg.albumId !== null
+        if(pg.albumId
           || pg.type == 'instagram'
           || (pg.type == 'local' && !pg.imageData.hasOwnProperty('albums'))){
           //load single Album

--- a/js/plusgallery.js
+++ b/js/plusgallery.js
@@ -364,7 +364,7 @@ SLIDEFADE
               if(i < albumTotal){
                 galleryTitle = obj.title._content;
                 galleryImage = 'https://farm' + obj.farm + '.staticflickr.com/' + obj.server + '/' + obj.primary + '_' + obj.secret + '_n.jpg';
-                galleryJSON = 'https://api.flickr.com/services/rest/?&method=flickr.photosets.getPhotos&api_key=' + pg.apiKey + '&photoset_id=' + obj.id + '=&format=json&jsoncallback=?';
+                galleryJSON = 'https://api.flickr.com/services/rest/?&method=flickr.photosets.getPhotos&api_key=' + pg.apiKey + '&photoset_id=' + obj.id + '&format=json&jsoncallback=?';
     
                 pg.loadAlbums(galleryTitle,galleryImage,galleryJSON);
               }
@@ -537,7 +537,7 @@ SLIDEFADE
           pg.loadGallery(url);
           break;
         case 'flickr':
-          url = 'https://api.flickr.com/services/rest/?&method=flickr.photosets.getPhotos&api_key=' + pg.apiKey + '&photoset_id=' + pg.albumId + '=&format=json&jsoncallback=?';
+          url = 'https://api.flickr.com/services/rest/?&method=flickr.photosets.getPhotos&api_key=' + pg.apiKey + '&photoset_id=' + pg.albumId + '&format=json&jsoncallback=?';
           pg.loadGallery(url);
           break;
         case 'facebook':


### PR DESCRIPTION
This pull request fixes two bugs:

1. The URLs for Flickr's getPhotos calls had typos in them (extra `=` characters).
2. The gallery was loading in single album mode even when the `albumId` option was `undefined` (it was being tested explicitly against `null`).